### PR TITLE
Add a small script to build for all architectures and lipo the results together

### DIFF
--- a/build-ios-lib.sh
+++ b/build-ios-lib.sh
@@ -1,0 +1,6 @@
+xcodebuild clean > /dev/null; rm -rf build;
+xcodebuild -scheme OTRKit -configuration Release -sdk iphonesimulator CONFIGURATION_BUILD_DIR='build/i386' > /dev/null
+xcodebuild -scheme OTRKit -configuration Release -sdk iphoneos CONFIGURATION_BUILD_DIR='build/arm' > /dev/null
+mkdir build/lib; lipo -create build/i386/libOTRKit.a build/arm/libOTRKit.a -output build/lib/libOTRKit.a
+
+echo "Done. Look in build/lib/ for the finished library."


### PR DESCRIPTION
The main motivation for this is to make it easier for projects that don't use git for their version control to use OTRKit.
