### PR TITLE
Don’t create a new pollTimer if the interval is 0

### DIFF
--- a/OTRKit/OTRKit.m
+++ b/OTRKit/OTRKit.m
@@ -592,7 +592,13 @@ static void timer_control_cb(void *opdata, unsigned int interval)
         [otrKit.pollTimer invalidate];
         otrKit.pollTimer = nil;
     }
-    otrKit.pollTimer = [NSTimer scheduledTimerWithTimeInterval:interval target:otrKit selector:@selector(messagePoll) userInfo:nil repeats:YES];
+    if (interval > 0) {
+        otrKit.pollTimer = [NSTimer scheduledTimerWithTimeInterval:interval
+                                                            target:otrKit
+                                                          selector:@selector(messagePoll)
+                                                          userInfo:nil
+                                                           repeats:YES];
+    }
 }
 
 static OtrlMessageAppOps ui_ops = {


### PR DESCRIPTION
It may result in infinite timer_control_cb calls (I encountered this bug in the project I'm working on)
See https://github.com/ChatSecure/OTRKit/blob/master/dependencies/include/libotr/message.h#L268 for details
