### PR TITLE
Issues with managing fingerprint trust

### DIFF
--- a/OTRKit/OTRFingerprint.h
+++ b/OTRKit/OTRFingerprint.h
@@ -39,5 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** Returns true if trustLevel = (OTRTrustLevelTrustedTofu || OTRTrustLevelTrustedTofu) */
 - (BOOL) isTrusted;
 
+- (BOOL) isEqualToFingerprint:(OTRFingerprint*)fingerprint;
+
 @end
 NS_ASSUME_NONNULL_END

--- a/OTRKit/OTRFingerprint.m
+++ b/OTRKit/OTRFingerprint.m
@@ -13,7 +13,7 @@
 - (instancetype) initWithUsername:(NSString*)username
                       accountName:(NSString*)accountName
                          protocol:(NSString*)protocol
-                      fingerprint:(NSString*)fingerprint
+                      fingerprint:(NSData*)fingerprint
                        trustLevel:(OTRTrustLevel)trustLevel {
     NSParameterAssert(username != nil);
     NSParameterAssert(accountName != nil);
@@ -33,6 +33,17 @@
 - (BOOL) isTrusted {
     return self.trustLevel == OTRTrustLevelTrustedUser ||
     self.trustLevel == OTRTrustLevelTrustedTofu;
+}
+
+- (BOOL) isEqualToFingerprint:(OTRFingerprint*)fingerprint
+{
+    if (!fingerprint) { return NO; }
+    
+    return [self.username isEqualToString:fingerprint.username] &&
+           [self.accountName isEqualToString:fingerprint.accountName] &&
+           [self.protocol isEqualToString:self.protocol] &&
+           [self.fingerprint isEqualToData:fingerprint.fingerprint] &&
+           self.trustLevel == fingerprint.trustLevel;
 }
 
 @end

--- a/OTRKit/OTRKit.m
+++ b/OTRKit/OTRKit.m
@@ -1264,7 +1264,6 @@ static OtrlMessageAppOps ui_ops = {
         }
         // Get root context if we're a child context
         context = [self rootContextForContext:context];
-        BOOL stop = NO;
         Fingerprint * targetFingerprint = [self internalFingerprintForUsername:username accountName:accountName protocol:protocol fingerprintData:fingerprintData];
         if (targetFingerprint) {
             //will not delete if it is the active fingerprint;

--- a/OTRKit/OTRKit.m
+++ b/OTRKit/OTRKit.m
@@ -1286,6 +1286,7 @@ static OtrlMessageAppOps ui_ops = {
     NSString *username = fingerprint.username;
     NSString *accountName = fingerprint.accountName;
     NSString *protocol = fingerprint.protocol;
+    NSData *fingerprintData = fingerprint.fingerprint;
     [self performBlock:^{
         ConnContext * context = [self contextForUsername:username accountName:accountName protocol:protocol];
         if (!context) {
@@ -1295,18 +1296,7 @@ static OtrlMessageAppOps ui_ops = {
         // Get root context if we're a child context
         context = [self rootContextForContext:context];
         BOOL stop = NO;
-        Fingerprint * targetFingerprint = NULL;
-        Fingerprint * currentFingerprint = context->fingerprint_root.next;
-        while (currentFingerprint && !stop) {
-            NSData *currentFingerprintData = [NSData dataWithBytesNoCopy:currentFingerprint->fingerprint length:kOTRKitFingerprintBytes];
-            if ([currentFingerprintData isEqualToData:fingerprint.fingerprint]) {
-                targetFingerprint = currentFingerprint;
-                stop = YES;
-            }
-            else {
-                currentFingerprint = currentFingerprint->next;
-            }
-        }
+        Fingerprint * targetFingerprint = [self internalFingerprintForUsername:username accountName:accountName protocol:protocol fingerprintData:fingerprintData];
         if (targetFingerprint) {
             //will not delete if it is the active fingerprint;
             otrl_context_forget_fingerprint(targetFingerprint, 0);

--- a/Tests/Shared/OTRKitFingerprintTests.m
+++ b/Tests/Shared/OTRKitFingerprintTests.m
@@ -42,7 +42,7 @@
 - (void) testFingerprintExchange {
     self.fingerprintExchange = [self expectationWithDescription:@"Fingerprint Exchange"];
     [self.otrKitAlice initiateEncryptionWithUsername:kOTRTestAccountBob accountName:kOTRTestAccountAlice protocol:kOTRTestProtocolXMPP];
-    [self waitForExpectationsWithTimeout:500 handler:^(NSError * _Nullable error) {
+    [self waitForExpectationsWithTimeout:10 handler:^(NSError * _Nullable error) {
         if (error) {
             NSLog(@"%@",error);
         }

--- a/Tests/Shared/OTRKitFingerprintTests.m
+++ b/Tests/Shared/OTRKitFingerprintTests.m
@@ -108,6 +108,11 @@ updateMessageState:(OTRKitMessageState)messageState
         //Make sure we successfully changed the fingerprint trust level.
         XCTAssertTrue([bobsFingerprintForAlice isEqualToFingerprint:fetchedBobsFingerprintForAlice]);
         
+        NSError *error = nil;
+        [self.otrKitBob deleteFingerprint:fetchedBobsFingerprintForAlice error:&error];
+        XCTAssertNil(error);
+        XCTAssertEqual([self.otrKitBob allFingerprints].count, 0);
+        
         [self.fingerprintExchange fulfill];
         self.fingerprintExchange = nil;
     }

--- a/Tests/Shared/OTRKitFingerprintTests.m
+++ b/Tests/Shared/OTRKitFingerprintTests.m
@@ -42,7 +42,7 @@
 - (void) testFingerprintExchange {
     self.fingerprintExchange = [self expectationWithDescription:@"Fingerprint Exchange"];
     [self.otrKitAlice initiateEncryptionWithUsername:kOTRTestAccountBob accountName:kOTRTestAccountAlice protocol:kOTRTestProtocolXMPP];
-    [self waitForExpectationsWithTimeout:5 handler:^(NSError * _Nullable error) {
+    [self waitForExpectationsWithTimeout:500 handler:^(NSError * _Nullable error) {
         if (error) {
             NSLog(@"%@",error);
         }
@@ -61,7 +61,10 @@ updateMessageState:(OTRKitMessageState)messageState
     XCTAssertNotNil(username);
     XCTAssertNotNil(accountName);
     XCTAssertNotNil(protocol);
-    XCTAssertNotNil(fingerprint);
+    if (messageState == OTRKitMessageStateEncrypted) {
+        XCTAssertNotNil(fingerprint);
+    }
+    
     NSLog(@"updateMessageState: %@ %@ %@ %@", username, accountName, protocol, fingerprint.fingerprint);
     
     // Testing fingerprint exchange.

--- a/Tests/Shared/OTRKitTests.m
+++ b/Tests/Shared/OTRKitTests.m
@@ -60,7 +60,7 @@ static NSString * const kOTRTestMessage = @"Hello World";
 
     [self.otrKitAlice initiateEncryptionWithUsername:kOTRTestAccountBob accountName:kOTRTestAccountAlice protocol:kOTRTestProtocolXMPP];
 
-    [self waitForExpectationsWithTimeout:10 handler:^(NSError *error) {
+    [self waitForExpectationsWithTimeout:600 handler:^(NSError *error) {
         if (error) {
             NSLog(@"failed waitForExpectationsWithTimeout: %@", error);
         }


### PR DESCRIPTION
I'll use this pull request to track progress on fixing a few issues with the new fingerprint interface.

- [x] Initial fingerprints are not set to OTRTrustLevelTrustedTofu.
- [x] Changing a fingerprint trust level without an active session fails.

Slightly unrelated I noticed that when I send `disableEncryptionWithUsername` I only get one callback at `updateMessageState` from the sending OTRKit and not the receiving OTRKit. 
